### PR TITLE
fix: edit makefile relative paths

### DIFF
--- a/makefile
+++ b/makefile
@@ -4,8 +4,8 @@ build:
 	read -p "Enter IP Address:" ip; \
 	sed -i -e "s|\"common_name\": \".*|\"common_name\": \"$$ip\"\,|g" ./mps/.mpsrc -e "s|'localhost'|\'$$ip\'|g" ./sample-web-ui/src/app.config.js
 	cd ./mps && npm install
-	cd ../rps && npm install
-	cd ../sample-web-ui && npm install
+	cd ./rps && npm install
+	cd ./sample-web-ui && npm install
 
 MICROSERVICES= \
 	run-ui & \
@@ -15,10 +15,10 @@ MICROSERVICES= \
 .PHONY: $(MICROSERVICES)
 
 run-rps: 
-	(cd ../rps && npm run dev)
+	(cd ./rps && npm run dev)
 
 run-ui: 
-	(cd ../sample-web-ui && npm start)
+	(cd ./sample-web-ui && npm start)
 
 run-mps: 
 	(cd ./mps && npm run dev) 

--- a/makefile
+++ b/makefile
@@ -15,13 +15,13 @@ MICROSERVICES= \
 .PHONY: $(MICROSERVICES)
 
 run-rps: 
-	(cd ./rps && npm run dev)
+	(cd ./rps && npm run devx)
 
 run-ui: 
 	(cd ./sample-web-ui && npm start)
 
 run-mps: 
-	(cd ./mps && npm run dev) 
+	(cd ./mps && npm run devx) 
 
 run:
 	echo "run each service in a separate terminal window (i.e. make run-ui)"


### PR DESCRIPTION
Changing relative paths to run without error.  I'm guessing it's cause Makefile runs each line break in its own shell process? Opted to change paths rather than combine into single line for clarity.