### PR TITLE
build(docker): add mqtt profile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,6 +159,8 @@ services:
       - ./mosquitto.conf:/mosquitto/config/mosquitto.conf
     networks:
       - openamtnetwork
+    profiles:
+      - "mqtt"
 volumes:
     app-volume:
     private-volume:


### PR DESCRIPTION
This PR adds a docker compose profile called MQTT. More info can be found about profiles here: https://docs.docker.com/compose/profiles/#enable-profiles