### PR TITLE
fix(mps-router): connection string missing required parameter for sslmode

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
     restart: always
     image: intel/oact-mpsrouter:latest
     environment:
-      MPS_CONNECTION_STRING: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/mpsdb
+      MPS_CONNECTION_STRING: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/mpsdb?sslmode=disable
       PORT: ${PORT}
       MPS_PORT: ${MPSWEBPORT}
     healthcheck:


### PR DESCRIPTION
closes #227 