### PR TITLE
fix(console): set GIN_MODE=debug to prevent xdg-open panic in container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       SECRET_TOKEN: ${VAULT_TOKEN}
       HTTP_PORT: "8181"
       LOG_LEVEL: info
+      GIN_MODE: debug
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8181/api/v1/health"]
       interval: 12s


### PR DESCRIPTION
## Problem

The `console` service was crash-looping on startup. Two issues were identified and resolved:

### 1. Dirty database migration (`schema_migrations`)
Migration version `20250701000000` was marked as `dirty=true` in the database, causing the app to exit with:
```
App init error: migrate error: up error: Dirty database version 20250701000000. Fix and force version.
```

**Root cause:** A previous migration run failed mid-flight, leaving `golang-migrate` unable to proceed.

**Fix:** Clear the dirty flag by running the following against the `db` container:
```bash
docker exec device-management-toolkit-db-1 psql \
  -U postgresadmin \
  -d rpsdb \
  -c "UPDATE schema_migrations SET dirty = false WHERE version = 20250701000000;"
```

Replace 20250701000000 with the actual dirty version shown in the error if it differs.
This is a one-time manual recovery step — once cleared, the app will re-run the migration on next startup.

### 2. `xdg-open` panic on startup (this commit)
After the migration was fixed, the app panicked with:
```
panic: exec: "xdg-open": executable file not found in $PATH
```
The `handleDebugMode` function spawns a goroutine to open a browser via `xdg-open` whenever `GIN_MODE != "debug"`. In the headless scratch container there is no display server, so this always panics.

**Fix:** Added `GIN_MODE: debug` to the `console` service environment in `docker-compose.yml`. This suppresses the `launchBrowser` goroutine and allows the service to start normally.

### 3. Missing `APP_ENCRYPTION_KEY`
`APP_ENCRYPTION_KEY` was empty, causing the app to fall through to the D-Bus keyring which is not available in the container. This is set in the local `.env` file (gitignored).