### PR TITLE
ci: add manual installer build workflows

### DIFF
--- a/.github/workflows/installer-linux.yml
+++ b/.github/workflows/installer-linux.yml
@@ -1,0 +1,104 @@
+name: Build Linux Installer
+
+on:
+  workflow_dispatch:
+    inputs:
+      console_version:
+        description: "Console release tag to package (e.g. v1.26.0). Empty = latest."
+        required: false
+        default: ""
+      installer_version:
+        description: "Installer version string baked into the packages. Empty = derived from console tag."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build deb/rpm
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout deployment repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Resolve console version
+        id: ver
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUESTED: ${{ inputs.console_version }}
+          INSTALLER_VERSION_INPUT: ${{ inputs.installer_version }}
+        run: |
+          set -euo pipefail
+          if [ -n "$REQUESTED" ]; then
+            tag="$REQUESTED"
+          else
+            tag=$(gh release view --repo device-management-toolkit/console --json tagName -q .tagName)
+          fi
+          if [ -n "$INSTALLER_VERSION_INPUT" ]; then
+            installer_version="$INSTALLER_VERSION_INPUT"
+          else
+            installer_version="${tag#v}"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "installer_version=$installer_version" >> "$GITHUB_OUTPUT"
+          echo "Console tag: $tag"
+          echo "Installer version: $installer_version"
+
+      - name: Checkout console source at release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: device-management-toolkit/console
+          ref: ${{ steps.ver.outputs.tag }}
+          path: services/console
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version-file: services/console/go.mod
+
+      - name: Install build dependencies
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          # CGO system-tray deps (libgtk-3-dev + appindicator), matches the tray build.
+          sudo apt-get install -y libgtk-3-dev libayatana-appindicator3-dev
+          # nfpm produces the .deb / .rpm packages.
+          go install github.com/goreleaser/nfpm/v2/cmd/nfpm@latest
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Build deb/rpm packages
+        env:
+          INSTALLER_VERSION: ${{ steps.ver.outputs.installer_version }}
+        run: |
+          chmod +x ./installers/linux/build-packages.sh
+          ./installers/linux/build-packages.sh "$INSTALLER_VERSION" amd64
+
+      - name: Publish .deb installers to release
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/linux/*.deb
+          file_glob: true
+          tag: v${{ steps.ver.outputs.installer_version }}
+          overwrite: true
+          body: "Device Management Toolkit Console installers"
+
+      - name: Publish .rpm installers to release
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/linux/*.rpm
+          file_glob: true
+          tag: v${{ steps.ver.outputs.installer_version }}
+          overwrite: true
+          body: "Device Management Toolkit Console installers"

--- a/.github/workflows/installer-macos.yml
+++ b/.github/workflows/installer-macos.yml
@@ -1,0 +1,103 @@
+name: Build macOS Installer
+
+on:
+  workflow_dispatch:
+    inputs:
+      console_version:
+        description: "Console release tag to package (e.g. v1.26.0). Empty = latest."
+        required: false
+        default: ""
+      installer_version:
+        description: "Installer version string baked into the .pkg. Empty = derived from console tag."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build .pkg
+    runs-on: macos-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout deployment repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Resolve console version
+        id: ver
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUESTED: ${{ inputs.console_version }}
+          INSTALLER_VERSION_INPUT: ${{ inputs.installer_version }}
+        run: |
+          set -euo pipefail
+          if [ -n "$REQUESTED" ]; then
+            tag="$REQUESTED"
+          else
+            tag=$(gh release view --repo device-management-toolkit/console --json tagName -q .tagName)
+          fi
+          if [ -n "$INSTALLER_VERSION_INPUT" ]; then
+            installer_version="$INSTALLER_VERSION_INPUT"
+          else
+            installer_version="${tag#v}"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "installer_version=$installer_version" >> "$GITHUB_OUTPUT"
+          echo "Console tag: $tag"
+          echo "Installer version: $installer_version"
+
+      - name: Checkout console source at release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: device-management-toolkit/console
+          ref: ${{ steps.ver.outputs.tag }}
+          path: services/console
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version-file: services/console/go.mod
+
+      - name: Build .pkg installers
+        env:
+          INSTALLER_VERSION: ${{ steps.ver.outputs.installer_version }}
+        run: |
+          chmod +x ./installers/macos/build-pkg.sh
+          ./installers/macos/build-pkg.sh "$INSTALLER_VERSION" arm64
+
+      # TODO: Apple signing + notarization.
+      # When ready, add these steps before the upload, gated on secret presence:
+      #
+      #   - Import Developer ID Installer cert from APPLE_DEVELOPER_ID_CERT_P12_BASE64
+      #     into a temporary keychain using `security create-keychain` / `security import`.
+      #   - productsign --sign "Developer ID Installer: <Team Name>" \
+      #         dist/darwin/console_<v>_macos_<arch>.pkg dist/darwin/<v>-signed.pkg
+      #   - xcrun notarytool submit dist/darwin/<v>-signed.pkg \
+      #         --apple-id "$AC_USERNAME" --password "$AC_PASSWORD" --team-id "$AC_TEAM_ID" --wait
+      #   - xcrun stapler staple dist/darwin/<v>-signed.pkg
+      #
+      # Required repo secrets:
+      #   APPLE_DEVELOPER_ID_CERT_P12_BASE64   base64-encoded .p12
+      #   APPLE_DEVELOPER_ID_CERT_PASSWORD     .p12 password
+      #   APPLE_KEYCHAIN_PASSWORD              ephemeral keychain password
+      #   AC_USERNAME                          Apple ID for notarization
+      #   AC_PASSWORD                          app-specific password
+      #   AC_TEAM_ID                           Developer Team ID
+
+      - name: Publish installers to release
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/darwin/*.pkg
+          file_glob: true
+          tag: v${{ steps.ver.outputs.installer_version }}
+          overwrite: true
+          body: "Device Management Toolkit Console installers"

--- a/.github/workflows/installer-windows.yml
+++ b/.github/workflows/installer-windows.yml
@@ -1,0 +1,89 @@
+name: Build Windows Installer
+
+on:
+  workflow_dispatch:
+    inputs:
+      console_version:
+        description: "Console release tag to package (e.g. v1.26.0). Empty = latest."
+        required: false
+        default: ""
+      installer_version:
+        description: "Installer version string baked into the .exe. Empty = derived from console tag."
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build NSIS setup.exe
+    runs-on: windows-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout deployment repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Resolve console version
+        id: ver
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REQUESTED: ${{ inputs.console_version }}
+          INSTALLER_VERSION_INPUT: ${{ inputs.installer_version }}
+        run: |
+          set -euo pipefail
+          if [ -n "$REQUESTED" ]; then
+            tag="$REQUESTED"
+          else
+            tag=$(gh release view --repo device-management-toolkit/console --json tagName -q .tagName)
+          fi
+          if [ -n "$INSTALLER_VERSION_INPUT" ]; then
+            installer_version="$INSTALLER_VERSION_INPUT"
+          else
+            installer_version="${tag#v}"
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "installer_version=$installer_version" >> "$GITHUB_OUTPUT"
+          echo "Console tag: $tag"
+          echo "Installer version: $installer_version"
+
+      - name: Checkout console source at release tag
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: device-management-toolkit/console
+          ref: ${{ steps.ver.outputs.tag }}
+          path: services/console
+          persist-credentials: false
+
+      - name: Setup Go
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+        with:
+          go-version-file: services/console/go.mod
+
+      - name: Install NSIS
+        run: choco install nsis -y --no-progress
+
+      - name: Build NSIS installers
+        shell: bash
+        env:
+          INSTALLER_VERSION: ${{ steps.ver.outputs.installer_version }}
+        run: |
+          chmod +x ./installers/windows/build-installers.sh
+          ./installers/windows/build-installers.sh "$INSTALLER_VERSION" x64
+
+      - name: Publish installers to release
+        uses: svenstaro/upload-release-action@29e53e917877a24fad85510ded594ab3c9ca12de # v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: dist/windows/*_setup.exe
+          file_glob: true
+          tag: v${{ steps.ver.outputs.installer_version }}
+          overwrite: true
+          body: "Device Management Toolkit Console installers"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 .vscode/
+dist/
 **/.DS_Store
 **/Thumbs.db
 **/node_modules/


### PR DESCRIPTION
## Summary
- Adds three `workflow_dispatch` workflows under `.github/workflows/`, one per platform (macOS, Linux, Windows).
- Each workflow resolves a console release tag, checks out console source at that tag, sets up Go, runs the platform installer script, and publishes the resulting installers to the matching GitHub release (`contents: write`, `svenstaro/upload-release-action` with `overwrite: true`).
- macOS builds `.pkg` via `installers/macos/build-pkg.sh` (Apple signing/notarization stubbed with TODO + required secrets documented inline).
- Linux builds `.deb`/`.rpm` via `installers/linux/build-packages.sh` (installs GTK/appindicator deps + nfpm).
- Windows builds the NSIS `setup.exe` via `installers/windows/build-installers.sh` (installs NSIS via choco).
- Adds `dist/` to `.gitignore`.

Depends on the installer scripts landing first (see #571 — once that merges, these workflows become runnable).

## Test plan
- [ ] Manually dispatch each workflow (`Build macOS Installer`, `Build Linux Installer`, `Build Windows Installer`) from the Actions tab after installer scripts land
- [ ] Verify each build produces its installers and publishes them as assets on the `v<installer_version>` release
