### PR TITLE
feat: add Windows NSIS installer for Console on-prem

### DIFF
--- a/installers/windows/README.md
+++ b/installers/windows/README.md
@@ -1,17 +1,55 @@
 # Windows Installer (Console — on-prem)
 
-Native Windows installer for Device Management Toolkit (Console) on-prem.
+Native Windows NSIS installer for Device Management Toolkit (Console) on-prem.
+Two editions are produced per build, both with the system tray:
 
-**Status:** Not yet implemented.
+- **Full** — system tray plus the embedded web UI
+- **Headless** — system tray plus the API only (no web UI bundled)
 
-## Scope
+## Build
 
-- `.msi` (WiX) primary, optional standalone `.exe`.
-- x86_64.
-- Windows Service registration.
-- Idempotent reinstall and clean uninstall.
+Run from **Windows** in **Git Bash** (or MSYS2). The script hardcodes
+`C:\Program Files (x86)\NSIS\makensis.exe` and uses Git Bash–style paths, so
+it does not run on Linux or macOS.
 
-## Out of scope
+Prereqs on the build host:
 
-- Cloud (use `bicep/` or `charts/` with `values-cloud.yaml`).
-- Multi-host clustering (use `charts/` with `values-onprem.yaml`).
+- Git Bash or MSYS2
+- NSIS 3.x at the default install path
+- Go 1.25+ — only when building binaries from source (see below); matches
+  `services/console/go.mod`
+- A mingw-w64 `gcc` on `PATH` — only when building from source; both
+  editions use `CGO_ENABLED=1` for the tray dependency
+
+```bash
+./build-installers.sh [VERSION] [ARCH]
+```
+
+Defaults: `VERSION=0.0.0`, `ARCH=x64`. `ARCH` only affects output filenames
+— the Go build is hardcoded to `GOARCH=amd64`.
+
+Outputs to `dist/windows/`:
+
+- `console_<VERSION>_windows_<ARCH>_setup.exe`           (full)
+- `console_<VERSION>_windows_<ARCH>_headless_setup.exe`  (headless)
+
+### Binary sourcing
+
+The script needs two prebuilt binaries:
+`console_windows_<ARCH>.exe` and `console_windows_<ARCH>_headless.exe`.
+
+- **Release-train (preferred):** point `BINARY_DIR` at a directory holding
+  the binaries from a tagged Console release. No Go/CGO toolchain needed.
+  ```bash
+  BINARY_DIR=/c/path/to/release/windows ./build-installers.sh 3.1.0 x64
+  ```
+- **Local dev:** initialize the `services/console` submodule and the script
+  will build the binaries from source (needs Go + a CGO-capable mingw
+  toolchain).
+  ```bash
+  git submodule update --init services/console
+  ./build-installers.sh
+  ```
+
+If neither path is satisfied, the script exits with a clear error.
+

--- a/installers/windows/build-installers.sh
+++ b/installers/windows/build-installers.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+# Device Management Toolkit Console - Windows Installer Build Script
+# Copyright (c) Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+#
+# Builds two NSIS installers: one for UI edition, one for headless.
+# Requires: NSIS (makensis) installed and on PATH.
+
+set -e
+
+VERSION="${1:-0.0.0}"
+ARCH="${2:-x64}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+NSI_FILE="$SCRIPT_DIR/console.nsi"
+OUTPUT_DIR="$REPO_ROOT/dist/windows"
+
+# VI_VERSION must be numeric X.X.X.X — strip any pre-release suffix.
+VI_VERSION="$(echo "$VERSION" | sed 's/-.*//').0"
+
+# Console source is consumed via the services/console submodule when binaries
+# are built locally. For release-train builds, set BINARY_DIR to a directory
+# containing prebuilt binaries (see expected names below) to skip building.
+CONSOLE_SRC="$REPO_ROOT/services/console"
+BINARY_DIR="${BINARY_DIR:-$OUTPUT_DIR}"
+UI_BINARY="$BINARY_DIR/console_windows_${ARCH}.exe"
+HEADLESS_BINARY="$BINARY_DIR/console_windows_${ARCH}_headless.exe"
+
+echo "Building Windows NSIS installers..."
+echo "Version: $VERSION"
+echo "Architecture: $ARCH"
+echo "Binary dir: $BINARY_DIR"
+echo ""
+
+mkdir -p "$OUTPUT_DIR"
+
+if [ -f "$UI_BINARY" ] && [ -f "$HEADLESS_BINARY" ]; then
+    echo "=== Using prebuilt binaries ==="
+    echo "  UI:       $UI_BINARY"
+    echo "  Headless: $HEADLESS_BINARY"
+else
+    echo "=== Building Binaries from $CONSOLE_SRC ==="
+    if [ ! -f "$CONSOLE_SRC/cmd/app/main.go" ] && [ ! -d "$CONSOLE_SRC/cmd/app" ]; then
+        echo "Error: console source not found at $CONSOLE_SRC" >&2
+        echo "Either initialize the submodule:" >&2
+        echo "    git submodule update --init services/console" >&2
+        echo "or provide prebuilt binaries via BINARY_DIR env var:" >&2
+        echo "    BINARY_DIR=/path/to/dist/windows $0 $VERSION $ARCH" >&2
+        echo "  expected files: $(basename "$UI_BINARY"), $(basename "$HEADLESS_BINARY")" >&2
+        exit 1
+    fi
+
+    mkdir -p "$BINARY_DIR"
+
+    echo "Building UI binary with tray (CGO_ENABLED=1)..."
+    (cd "$CONSOLE_SRC" && CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -tags=tray -ldflags "-s -w" -trimpath -o "$UI_BINARY" ./cmd/app)
+    echo "  Built: $UI_BINARY"
+
+    echo "Building headless binary with tray (CGO_ENABLED=1)..."
+    (cd "$CONSOLE_SRC" && CGO_ENABLED=1 GOOS=windows GOARCH=amd64 go build -tags='tray noui' -ldflags "-s -w" -trimpath -o "$HEADLESS_BINARY" ./cmd/app)
+    echo "  Built: $HEADLESS_BINARY"
+fi
+
+echo ""
+
+# Build NSIS installers
+echo "=== Building NSIS Installers ==="
+
+# Use full path to makensis from NSIS installation
+MAKENSIS="/c/Program Files (x86)/NSIS/makensis.exe"
+
+if [ ! -f "$MAKENSIS" ]; then
+    echo "Error: makensis not found at $MAKENSIS" >&2
+    echo "Please install NSIS from https://nsis.sourceforge.io/" >&2
+    exit 1
+fi
+
+# Convert Unix-style paths to Windows paths for NSIS (backslashes)
+UI_BINARY_WIN=$(echo "$UI_BINARY" | sed 's|^/c|C:|' | sed 's|/|\\|g')
+HEADLESS_BINARY_WIN=$(echo "$HEADLESS_BINARY" | sed 's|^/c|C:|' | sed 's|/|\\|g')
+
+echo "Building UI installer..."
+"$MAKENSIS" -DVERSION="$VERSION" -DVI_VERSION="$VI_VERSION" -DARCH="$ARCH" -DEDITION=ui -DBINARY="$UI_BINARY_WIN" "$NSI_FILE"
+mv "$SCRIPT_DIR/console_${VERSION}_windows_${ARCH}_setup.exe" "$OUTPUT_DIR/"
+echo "  Created: $OUTPUT_DIR/console_${VERSION}_windows_${ARCH}_setup.exe"
+
+echo "Building headless installer..."
+"$MAKENSIS" -DVERSION="$VERSION" -DVI_VERSION="$VI_VERSION" -DARCH="$ARCH" -DEDITION=headless -DBINARY="$HEADLESS_BINARY_WIN" "$NSI_FILE"
+mv "$SCRIPT_DIR/console_${VERSION}_windows_${ARCH}_headless_setup.exe" "$OUTPUT_DIR/"
+echo "  Created: $OUTPUT_DIR/console_${VERSION}_windows_${ARCH}_headless_setup.exe"
+
+echo ""
+echo "=== Build Complete ==="
+echo ""
+echo "Installers created:"
+echo "  UI:       $OUTPUT_DIR/console_${VERSION}_windows_${ARCH}_setup.exe"
+echo "  Headless: $OUTPUT_DIR/console_${VERSION}_windows_${ARCH}_headless_setup.exe"

--- a/installers/windows/build-installers.sh
+++ b/installers/windows/build-installers.sh
@@ -75,9 +75,15 @@ if [ ! -f "$MAKENSIS" ]; then
     exit 1
 fi
 
-# Convert Unix-style paths to Windows paths for NSIS (backslashes)
-UI_BINARY_WIN=$(echo "$UI_BINARY" | sed 's|^/c|C:|' | sed 's|/|\\|g')
-HEADLESS_BINARY_WIN=$(echo "$HEADLESS_BINARY" | sed 's|^/c|C:|' | sed 's|/|\\|g')
+# Convert Unix-style paths to Windows paths for NSIS. cygpath handles all
+# drives and MSYS mount points correctly (Git Bash ships with it).
+if ! command -v cygpath >/dev/null 2>&1; then
+    echo "Error: cygpath not found; required for Unix→Windows path conversion." >&2
+    echo "Install Git for Windows / MSYS2 to get cygpath." >&2
+    exit 1
+fi
+UI_BINARY_WIN=$(cygpath -w "$UI_BINARY")
+HEADLESS_BINARY_WIN=$(cygpath -w "$HEADLESS_BINARY")
 
 echo "Building UI installer..."
 "$MAKENSIS" -DVERSION="$VERSION" -DVI_VERSION="$VI_VERSION" -DARCH="$ARCH" -DEDITION=ui -DBINARY="$UI_BINARY_WIN" "$NSI_FILE"

--- a/installers/windows/console.nsi
+++ b/installers/windows/console.nsi
@@ -1,0 +1,455 @@
+; Device Management Toolkit Console - NSIS Installer Script
+; Copyright (c) Intel Corporation
+; SPDX-License-Identifier: Apache-2.0
+
+;--------------------------------
+; Includes
+
+!include "MUI2.nsh"
+!include "FileFunc.nsh"
+!include "LogicLib.nsh"
+!include "WinMessages.nsh"
+!include "StrFunc.nsh"
+!include "nsDialogs.nsh"
+!include "WordFunc.nsh"
+
+; Declare string functions we'll use (for installer)
+${StrStr}
+
+; Declare string functions for uninstaller (must use un. prefix)
+${UnStrRep}
+
+;--------------------------------
+; General Configuration
+
+!ifndef VERSION
+  !define VERSION "0.0.0"
+!endif
+
+!ifndef ARCH
+  !define ARCH "x64"
+!endif
+
+; Edition: "ui" or "headless" — set at build time via -DEDITION=<value>
+!ifndef EDITION
+  !define EDITION "ui"
+!endif
+
+; Binary to install — set at build time via -DBINARY=<path>
+!ifndef BINARY
+  !define BINARY "..\dist\windows\console_windows_x64.exe"
+!endif
+
+; Edition-specific naming
+!if "${EDITION}" == "headless"
+  !define EDITION_LABEL "Headless"
+  !define EDITION_SUFFIX "_headless"
+!else
+  !define EDITION_LABEL ""
+  !define EDITION_SUFFIX ""
+!endif
+
+Name "Device Management Toolkit Console ${VERSION}"
+OutFile "console_${VERSION}_windows_${ARCH}${EDITION_SUFFIX}_setup.exe"
+InstallDir "$PROGRAMFILES64\Device Management Toolkit\Console"
+InstallDirRegKey HKLM "Software\DeviceManagementToolkit\Console" "InstallDir"
+RequestExecutionLevel admin
+Unicode True
+
+; Compression
+SetCompressor /SOLID lzma
+SetCompressorDictSize 64
+
+;--------------------------------
+; Version Information
+
+; VI_VERSION must be numeric X.X.X.X format — passed from Makefile with
+; pre-release suffixes stripped. Falls back to VERSION.0 if not provided.
+!ifndef VI_VERSION
+  !define VI_VERSION "${VERSION}.0"
+!endif
+VIProductVersion "${VI_VERSION}"
+VIAddVersionKey "ProductName" "Device Management Toolkit Console"
+VIAddVersionKey "CompanyName" "Intel Corporation"
+VIAddVersionKey "LegalCopyright" "Copyright (c) Intel Corporation"
+VIAddVersionKey "FileDescription" "Device Management Toolkit Console Installer"
+VIAddVersionKey "FileVersion" "${VERSION}"
+VIAddVersionKey "ProductVersion" "${VERSION}"
+
+;--------------------------------
+; Variables
+
+Var Dialog
+Var PortLabel
+Var PortText
+Var PortValue
+Var TLSCheckbox
+Var TLSEnabled
+Var UsernameLabel
+Var UsernameText
+Var UsernameValue
+Var PasswordLabel
+Var PasswordText
+Var PasswordValue
+
+;--------------------------------
+; Interface Settings
+
+!define MUI_ABORTWARNING
+!define MUI_ICON "${NSISDIR}\Contrib\Graphics\Icons\modern-install.ico"
+!define MUI_UNICON "${NSISDIR}\Contrib\Graphics\Icons\modern-uninstall.ico"
+!define MUI_WELCOMEFINISHPAGE_BITMAP "${NSISDIR}\Contrib\Graphics\Wizard\win.bmp"
+
+; Show installation details
+ShowInstDetails show
+ShowUnInstDetails show
+
+;--------------------------------
+; Pages
+
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_LICENSE "..\..\LICENSE"
+!insertmacro MUI_PAGE_DIRECTORY
+Page custom ConfigPage ConfigPageLeave
+!insertmacro MUI_PAGE_COMPONENTS
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+;--------------------------------
+; Languages
+
+!insertmacro MUI_LANGUAGE "English"
+
+;--------------------------------
+; Configuration Page
+
+Function ConfigPage
+  !insertmacro MUI_HEADER_TEXT "Configuration" "Configure essential settings for the Console."
+
+  nsDialogs::Create 1018
+  Pop $Dialog
+
+  ${If} $Dialog == error
+    Abort
+  ${EndIf}
+
+  ; Port
+  ${NSD_CreateLabel} 0 0 60u 12u "HTTP Port:"
+  Pop $PortLabel
+
+  ${NSD_CreateText} 65u 0 50u 12u "8181"
+  Pop $PortText
+
+  ${NSD_CreateLabel} 120u 0 100% 12u "(default: 8181)"
+  Pop $0
+
+  ; TLS
+  ${NSD_CreateCheckbox} 0 25u 100% 12u "Enable TLS/HTTPS (recommended)"
+  Pop $TLSCheckbox
+  ${NSD_SetState} $TLSCheckbox ${BST_CHECKED}
+
+  ${NSD_CreateLabel} 15u 40u 100% 12u "A self-signed certificate will be generated if no certificate is provided."
+  Pop $0
+
+  ; Separator
+  ${NSD_CreateHLine} 0 60u 100% 1u
+  Pop $0
+
+  ; Admin credentials section
+  ${NSD_CreateLabel} 0 70u 100% 12u "Administrator Credentials (for standalone authentication):"
+  Pop $0
+
+  ; Username
+  ${NSD_CreateLabel} 0 90u 60u 12u "Username:"
+  Pop $UsernameLabel
+
+  ${NSD_CreateText} 65u 88u 120u 14u "standalone"
+  Pop $UsernameText
+
+  ; Password
+  ${NSD_CreateLabel} 0 112u 60u 12u "Password:"
+  Pop $PasswordLabel
+
+  ${NSD_CreatePassword} 65u 110u 120u 14u "G@ppm0ym"
+  Pop $PasswordText
+
+  ${NSD_CreateLabel} 190u 112u 100% 12u "(change from default!)"
+  Pop $0
+
+  nsDialogs::Show
+FunctionEnd
+
+Function ConfigPageLeave
+  ${NSD_GetText} $PortText $PortValue
+  ${NSD_GetState} $TLSCheckbox $TLSEnabled
+  ${NSD_GetText} $UsernameText $UsernameValue
+  ${NSD_GetText} $PasswordText $PasswordValue
+FunctionEnd
+
+;--------------------------------
+; Installer Sections
+
+Section "Console Application" SecApp
+  SectionIn RO ; Required section
+
+  SetOutPath "$INSTDIR"
+
+  ; Install the edition-specific binary as console.exe
+  File /oname=console.exe "${BINARY}"
+
+  ; Create config directory
+  CreateDirectory "$INSTDIR\config"
+
+  ; Create data directory
+  CreateDirectory "$INSTDIR\data"
+
+  ; Generate config.yml
+  Call WriteConfigFile
+
+  ; Store installation folder and edition
+  WriteRegStr HKLM "Software\DeviceManagementToolkit\Console" "InstallDir" "$INSTDIR"
+  WriteRegStr HKLM "Software\DeviceManagementToolkit\Console" "Version" "${VERSION}"
+  WriteRegStr HKLM "Software\DeviceManagementToolkit\Console" "Edition" "${EDITION}"
+
+  ; Create uninstaller
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+
+  ; Add to Add/Remove Programs
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DMTConsole" \
+                   "DisplayName" "Device Management Toolkit Console"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DMTConsole" \
+                   "UninstallString" "$\"$INSTDIR\Uninstall.exe$\""
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DMTConsole" \
+                   "QuietUninstallString" "$\"$INSTDIR\Uninstall.exe$\" /S"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DMTConsole" \
+                   "InstallLocation" "$INSTDIR"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DMTConsole" \
+                   "DisplayVersion" "${VERSION}"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DMTConsole" \
+                   "Publisher" "Intel Corporation"
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DMTConsole" \
+                     "NoModify" 1
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DMTConsole" \
+                     "NoRepair" 1
+
+  ; Calculate and store install size
+  ${GetSize} "$INSTDIR" "/S=0K" $0 $1 $2
+  IntFmt $0 "0x%08X" $0
+  WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DMTConsole" \
+                     "EstimatedSize" "$0"
+SectionEnd
+
+Section "Start Menu Shortcuts" SecStartMenu
+  CreateDirectory "$SMPROGRAMS\Device Management Toolkit"
+  CreateShortcut "$SMPROGRAMS\Device Management Toolkit\Console.lnk" "$INSTDIR\console.exe" "--tray"
+  CreateShortcut "$SMPROGRAMS\Device Management Toolkit\Uninstall Console.lnk" "$INSTDIR\Uninstall.exe"
+SectionEnd
+
+Section "Desktop Shortcut" SecDesktop
+  CreateShortcut "$DESKTOP\DMT Console.lnk" "$INSTDIR\console.exe" "--tray"
+SectionEnd
+
+Section /o "Add to PATH" SecPath
+  ; Add to system PATH using registry
+  ReadRegStr $0 HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "Path"
+
+  ; Check if already in PATH
+  ${StrStr} $1 $0 "$INSTDIR"
+  ${If} $1 == ""
+    ; Not in PATH, add it
+    WriteRegExpandStr HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "Path" "$0;$INSTDIR"
+    ; Record that we added to PATH
+    WriteRegStr HKLM "Software\DeviceManagementToolkit\Console" "AddedToPath" "1"
+    ; Broadcast environment change
+    SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
+  ${EndIf}
+SectionEnd
+
+Section /o "Run at Startup (System Tray)" SecStartup
+  ; Add to HKLM Run key so it launches with --tray on login
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Run" "DMTConsole" '"$INSTDIR\console.exe" --tray'
+
+  ; Record that we added startup entry
+  WriteRegStr HKLM "Software\DeviceManagementToolkit\Console" "StartupInstalled" "1"
+SectionEnd
+
+;--------------------------------
+; Write Config File Function
+
+Function WriteConfigFile
+  ; Determine TLS setting
+  ${If} $TLSEnabled == ${BST_CHECKED}
+    StrCpy $0 "true"
+  ${Else}
+    StrCpy $0 "false"
+  ${EndIf}
+
+  FileOpen $1 "$INSTDIR\config\config.yml" w
+
+  FileWrite $1 "app:$\r$\n"
+  FileWrite $1 "  name: console$\r$\n"
+  FileWrite $1 "  repo: device-management-toolkit/console$\r$\n"
+  FileWrite $1 "  version: ${VERSION}$\r$\n"
+  FileWrite $1 "  encryption_key: $\"$\"$\r$\n"
+  FileWrite $1 "  allow_insecure_ciphers: false$\r$\n"
+  FileWrite $1 "http:$\r$\n"
+  FileWrite $1 "  host: localhost$\r$\n"
+  FileWrite $1 "  port: $\"$PortValue$\"$\r$\n"
+  FileWrite $1 "  ws_compression: false$\r$\n"
+  FileWrite $1 "  tls:$\r$\n"
+  FileWrite $1 "    enabled: $0$\r$\n"
+  FileWrite $1 "    certFile: $\"$\"$\r$\n"
+  FileWrite $1 "    keyFile: $\"$\"$\r$\n"
+  FileWrite $1 "  allowed_origins:$\r$\n"
+  FileWrite $1 "    - $\"*$\"$\r$\n"
+  FileWrite $1 "  allowed_headers:$\r$\n"
+  FileWrite $1 "    - $\"*$\"$\r$\n"
+  FileWrite $1 "logger:$\r$\n"
+  FileWrite $1 "  log_level: info$\r$\n"
+  FileWrite $1 "secrets:$\r$\n"
+  FileWrite $1 "  address: http://localhost:8200$\r$\n"
+  FileWrite $1 "  token: $\"$\"$\r$\n"
+  FileWrite $1 "postgres:$\r$\n"
+  FileWrite $1 "  pool_max: 2$\r$\n"
+  FileWrite $1 "  url: $\"$\"$\r$\n"
+  FileWrite $1 "ea:$\r$\n"
+  FileWrite $1 "  url: http://localhost:8000$\r$\n"
+  FileWrite $1 "  username: $\"$\"$\r$\n"
+  FileWrite $1 "  password: $\"$\"$\r$\n"
+  FileWrite $1 "auth:$\r$\n"
+  FileWrite $1 "  disabled: false$\r$\n"
+  FileWrite $1 "  adminUsername: $\"$UsernameValue$\"$\r$\n"
+  FileWrite $1 "  adminPassword: $\"$PasswordValue$\"$\r$\n"
+  FileWrite $1 "  jwtKey: your_secret_jwt_key$\r$\n"
+  FileWrite $1 "  jwtExpiration: 24h0m0s$\r$\n"
+  FileWrite $1 "  redirectionJWTExpiration: 5m0s$\r$\n"
+  FileWrite $1 "  clientId: $\"$\"$\r$\n"
+  FileWrite $1 "  issuer: $\"$\"$\r$\n"
+  FileWrite $1 "  ui:$\r$\n"
+  FileWrite $1 "    clientId: $\"$\"$\r$\n"
+  FileWrite $1 "    issuer: $\"$\"$\r$\n"
+  FileWrite $1 "    scope: $\"$\"$\r$\n"
+  FileWrite $1 "    redirectUri: $\"$\"$\r$\n"
+  FileWrite $1 "    responseType: $\"code$\"$\r$\n"
+  FileWrite $1 "    requireHttps: false$\r$\n"
+  FileWrite $1 "    strictDiscoveryDocumentValidation: true$\r$\n"
+  FileWrite $1 "ui:$\r$\n"
+  FileWrite $1 "  externalUrl: $\"$\"$\r$\n"
+
+  FileClose $1
+FunctionEnd
+
+;--------------------------------
+; Section Descriptions
+
+!insertmacro MUI_FUNCTION_DESCRIPTION_BEGIN
+  !insertmacro MUI_DESCRIPTION_TEXT ${SecApp} "Install the Device Management Toolkit Console application. (Required)"
+  !insertmacro MUI_DESCRIPTION_TEXT ${SecStartMenu} "Create Start Menu shortcuts for easy access."
+  !insertmacro MUI_DESCRIPTION_TEXT ${SecDesktop} "Create a Desktop shortcut."
+  !insertmacro MUI_DESCRIPTION_TEXT ${SecPath} "Add the installation directory to the system PATH environment variable."
+  !insertmacro MUI_DESCRIPTION_TEXT ${SecStartup} "Run Console with system tray icon at Windows startup."
+!insertmacro MUI_FUNCTION_DESCRIPTION_END
+
+;--------------------------------
+; Uninstaller Section
+
+Section "Uninstall"
+  ; Remove startup entry if installed
+  ReadRegStr $0 HKLM "Software\DeviceManagementToolkit\Console" "StartupInstalled"
+  ${If} $0 == "1"
+    DeleteRegValue HKLM "Software\Microsoft\Windows\CurrentVersion\Run" "DMTConsole"
+  ${EndIf}
+
+  ; Remove from PATH if we added it
+  ReadRegStr $0 HKLM "Software\DeviceManagementToolkit\Console" "AddedToPath"
+  ${If} $0 == "1"
+    ReadRegStr $1 HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "Path"
+    ; Remove our path (try both with and without trailing semicolon)
+    ${UnStrRep} $2 $1 ";$INSTDIR" ""
+    ${UnStrRep} $2 $2 "$INSTDIR;" ""
+    ${UnStrRep} $2 $2 "$INSTDIR" ""
+    WriteRegExpandStr HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "Path" "$2"
+    ; Broadcast environment change
+    SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
+  ${EndIf}
+
+  ; Remove files
+  Delete "$INSTDIR\console.exe"
+  Delete "$INSTDIR\config\config.yml"
+  Delete "$INSTDIR\Uninstall.exe"
+
+  ; Remove directories (only if empty)
+  RMDir "$INSTDIR\config"
+  RMDir "$INSTDIR\data"
+  RMDir "$INSTDIR"
+  RMDir "$PROGRAMFILES64\Device Management Toolkit"
+
+  ; Remove shortcuts
+  Delete "$SMPROGRAMS\Device Management Toolkit\Console.lnk"
+  Delete "$SMPROGRAMS\Device Management Toolkit\Uninstall Console.lnk"
+  RMDir "$SMPROGRAMS\Device Management Toolkit"
+  Delete "$DESKTOP\DMT Console.lnk"
+
+  ; Remove registry keys
+  DeleteRegKey HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\DMTConsole"
+  DeleteRegKey HKLM "Software\DeviceManagementToolkit\Console"
+  DeleteRegKey /ifempty HKLM "Software\DeviceManagementToolkit"
+
+  ; Offer to remove user data. The DB and encryption key are tied together —
+  ; keeping one without the other is useless, so they're removed as a unit.
+  ; Silent uninstalls preserve data by default.
+  IfSilent skip_data_prompt
+  MessageBox MB_YESNO|MB_ICONQUESTION "Remove user data (database, logs, and encryption key from Credential Manager)?$\r$\n$\r$\nChoose No to preserve your configuration for a future reinstall." /SD IDNO IDNO skip_data_prompt
+    DetailPrint "Removing user data..."
+    RMDir /r "$APPDATA\device-management-toolkit"
+    RMDir /r "$LOCALAPPDATA\device-management-toolkit"
+    nsExec::Exec 'cmdkey /delete:device-management-toolkit:default-security-key'
+    Pop $0
+  skip_data_prompt:
+SectionEnd
+
+;--------------------------------
+; Functions
+
+Function .onInit
+  ; Set default values
+  StrCpy $PortValue "8181"
+  StrCpy $TLSEnabled ${BST_CHECKED}
+  StrCpy $UsernameValue "standalone"
+  StrCpy $PasswordValue "G@ppm0ym"
+
+  ; Check for admin rights
+  UserInfo::GetAccountType
+  Pop $0
+  ${If} $0 != "admin"
+    MessageBox MB_ICONSTOP "Administrator rights required!"
+    SetErrorLevel 740 ; ERROR_ELEVATION_REQUIRED
+    Quit
+  ${EndIf}
+
+  ; Check for existing installation. Block downgrades; allow same-version
+  ; reinstalls and upgrades but stop any running console.exe first so the
+  ; new binary can replace it.
+  ReadRegStr $0 HKLM "Software\DeviceManagementToolkit\Console" "Version"
+  ${If} $0 != ""
+    ${VersionCompare} "$0" "${VERSION}" $1
+    ${If} $1 == "1"
+      MessageBox MB_ICONSTOP "A newer version of Device Management Toolkit Console ($0) is already installed.$\r$\nPlease uninstall it before installing ${VERSION}."
+      Abort
+    ${EndIf}
+    DetailPrint "Stopping running Console instance..."
+    nsExec::Exec 'taskkill /F /IM console.exe'
+    Pop $2
+    Sleep 1500
+  ${EndIf}
+FunctionEnd
+
+Function un.onInit
+  ; Stop any running Console instance so files can be removed.
+  nsExec::Exec 'taskkill /F /IM console.exe'
+  Pop $0
+  Sleep 1500
+FunctionEnd

--- a/installers/windows/console.nsi
+++ b/installers/windows/console.nsi
@@ -15,6 +15,7 @@
 
 ; Declare string functions we'll use (for installer)
 ${StrStr}
+${StrRep}
 
 ; Declare string functions for uninstaller (must use un. prefix)
 ${UnStrRep}
@@ -88,9 +89,12 @@ Var TLSEnabled
 Var UsernameLabel
 Var UsernameText
 Var UsernameValue
+Var UsernameYaml
 Var PasswordLabel
 Var PasswordText
 Var PasswordValue
+Var PasswordYaml
+Var JwtKey
 
 ;--------------------------------
 ; Interface Settings
@@ -173,10 +177,10 @@ Function ConfigPage
   ${NSD_CreateLabel} 0 112u 60u 12u "Password:"
   Pop $PasswordLabel
 
-  ${NSD_CreatePassword} 65u 110u 120u 14u "G@ppm0ym"
+  ${NSD_CreatePassword} 65u 110u 120u 14u ""
   Pop $PasswordText
 
-  ${NSD_CreateLabel} 190u 112u 100% 12u "(change from default!)"
+  ${NSD_CreateLabel} 190u 112u 100% 12u "(min 8 characters, required)"
   Pop $0
 
   nsDialogs::Show
@@ -187,6 +191,71 @@ Function ConfigPageLeave
   ${NSD_GetState} $TLSCheckbox $TLSEnabled
   ${NSD_GetText} $UsernameText $UsernameValue
   ${NSD_GetText} $PasswordText $PasswordValue
+
+  ; Validate port is an integer in valid TCP range (1-65535)
+  Push $PortValue
+  Call ValidatePort
+  Pop $0
+  ${If} $0 == "0"
+    MessageBox MB_ICONSTOP "HTTP port must be a number between 1 and 65535."
+    Abort
+  ${EndIf}
+
+  ; Validate username is non-empty
+  ${If} $UsernameValue == ""
+    MessageBox MB_ICONSTOP "Administrator username is required."
+    Abort
+  ${EndIf}
+
+  ; Validate password length
+  StrLen $0 $PasswordValue
+  ${If} $0 < 8
+    MessageBox MB_ICONSTOP "Administrator password must be at least 8 characters."
+    Abort
+  ${EndIf}
+FunctionEnd
+
+; Returns 1 on stack if input is integer in [1,65535], else 0.
+Function ValidatePort
+  Exch $0           ; port string
+  Push $1           ; index
+  Push $2           ; char
+  Push $3           ; length
+
+  StrLen $3 $0
+  ${If} $3 == 0
+    StrCpy $0 "0"
+    Goto vp_done
+  ${EndIf}
+
+  StrCpy $1 0
+  vp_loop:
+    ${If} $1 >= $3
+      Goto vp_range
+    ${EndIf}
+    StrCpy $2 $0 1 $1
+    ${If} $2 S< "0"
+    ${OrIf} $2 S> "9"
+      StrCpy $0 "0"
+      Goto vp_done
+    ${EndIf}
+    IntOp $1 $1 + 1
+    Goto vp_loop
+
+  vp_range:
+    IntCmp $0 0 vp_bad
+    IntCmp $0 65535 vp_ok vp_ok vp_bad
+  vp_bad:
+    StrCpy $0 "0"
+    Goto vp_done
+  vp_ok:
+    StrCpy $0 "1"
+
+  vp_done:
+  Pop $3
+  Pop $2
+  Pop $1
+  Exch $0
 FunctionEnd
 
 ;--------------------------------
@@ -287,6 +356,20 @@ Function WriteConfigFile
     StrCpy $0 "false"
   ${EndIf}
 
+  ; Escape YAML-special chars in user input (backslash first, then double-quote)
+  ${StrRep} $UsernameYaml $UsernameValue "\" "\\"
+  ${StrRep} $UsernameYaml $UsernameYaml '"' '\"'
+  ${StrRep} $PasswordYaml $PasswordValue "\" "\\"
+  ${StrRep} $PasswordYaml $PasswordYaml '"' '\"'
+
+  ; Generate a random JWT signing key per install (64 hex chars)
+  nsExec::ExecToStack 'powershell.exe -NoProfile -Command "[guid]::NewGuid().ToString(\"N\") + [guid]::NewGuid().ToString(\"N\")"'
+  Pop $2
+  Pop $JwtKey
+  ; Strip CRLF from PowerShell output
+  ${StrRep} $JwtKey $JwtKey "$\r" ""
+  ${StrRep} $JwtKey $JwtKey "$\n" ""
+
   FileOpen $1 "$INSTDIR\config\config.yml" w
 
   FileWrite $1 "app:$\r$\n"
@@ -321,9 +404,9 @@ Function WriteConfigFile
   FileWrite $1 "  password: $\"$\"$\r$\n"
   FileWrite $1 "auth:$\r$\n"
   FileWrite $1 "  disabled: false$\r$\n"
-  FileWrite $1 "  adminUsername: $\"$UsernameValue$\"$\r$\n"
-  FileWrite $1 "  adminPassword: $\"$PasswordValue$\"$\r$\n"
-  FileWrite $1 "  jwtKey: your_secret_jwt_key$\r$\n"
+  FileWrite $1 "  adminUsername: $\"$UsernameYaml$\"$\r$\n"
+  FileWrite $1 "  adminPassword: $\"$PasswordYaml$\"$\r$\n"
+  FileWrite $1 "  jwtKey: $JwtKey$\r$\n"
   FileWrite $1 "  jwtExpiration: 24h0m0s$\r$\n"
   FileWrite $1 "  redirectionJWTExpiration: 5m0s$\r$\n"
   FileWrite $1 "  clientId: $\"$\"$\r$\n"
@@ -363,16 +446,17 @@ Section "Uninstall"
     DeleteRegValue HKLM "Software\Microsoft\Windows\CurrentVersion\Run" "DMTConsole"
   ${EndIf}
 
-  ; Remove from PATH if we added it
+  ; Remove from PATH if we added it. Tokenize on ';' and drop only the
+  ; entry that equals $INSTDIR (case-insensitive), so we don't corrupt
+  ; other entries that contain $INSTDIR as a substring or prefix.
   ReadRegStr $0 HKLM "Software\DeviceManagementToolkit\Console" "AddedToPath"
   ${If} $0 == "1"
     ReadRegStr $1 HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "Path"
-    ; Remove our path (try both with and without trailing semicolon)
-    ${UnStrRep} $2 $1 ";$INSTDIR" ""
-    ${UnStrRep} $2 $2 "$INSTDIR;" ""
-    ${UnStrRep} $2 $2 "$INSTDIR" ""
+    Push $1
+    Push "$INSTDIR"
+    Call un.RemovePathEntry
+    Pop $2
     WriteRegExpandStr HKLM "SYSTEM\CurrentControlSet\Control\Session Manager\Environment" "Path" "$2"
-    ; Broadcast environment change
     SendMessage ${HWND_BROADCAST} ${WM_SETTINGCHANGE} 0 "STR:Environment" /TIMEOUT=5000
   ${EndIf}
 
@@ -419,7 +503,7 @@ Function .onInit
   StrCpy $PortValue "8181"
   StrCpy $TLSEnabled ${BST_CHECKED}
   StrCpy $UsernameValue "standalone"
-  StrCpy $PasswordValue "G@ppm0ym"
+  StrCpy $PasswordValue ""
 
   ; Check for admin rights
   UserInfo::GetAccountType
@@ -452,4 +536,86 @@ Function un.onInit
   nsExec::Exec 'taskkill /F /IM console.exe'
   Pop $0
   Sleep 1500
+FunctionEnd
+
+; un.RemovePathEntry: takes (path-string, entry-to-remove) on stack,
+; returns rebuilt path-string on stack. Splits on ';' and drops entries
+; that equal the target entry (case-insensitive, trailing '\' ignored).
+Function un.RemovePathEntry
+  Exch $R0           ; target entry
+  Exch
+  Exch $R1           ; full PATH
+  Push $R2           ; result accumulator
+  Push $R3           ; current token
+  Push $R4           ; remaining path
+  Push $R5           ; semicolon index
+  Push $R6           ; remaining length
+  Push $R7           ; normalized target
+  Push $R8           ; scratch / normalized token
+
+  ; Normalize target: strip a single trailing backslash if present
+  StrCpy $R7 $R0
+  StrCpy $R8 $R7 "" -1
+  ${If} $R8 == "\"
+    StrCpy $R7 $R7 -1
+  ${EndIf}
+
+  StrCpy $R2 ""
+  StrCpy $R4 $R1
+
+  rpe_loop:
+    ${If} $R4 == ""
+      Goto rpe_done
+    ${EndIf}
+    StrCpy $R5 0
+    StrLen $R6 $R4
+    rpe_find:
+      ${If} $R5 >= $R6
+        StrCpy $R3 $R4
+        StrCpy $R4 ""
+        Goto rpe_have_token
+      ${EndIf}
+      StrCpy $R8 $R4 1 $R5
+      ${If} $R8 == ";"
+        StrCpy $R3 $R4 $R5
+        IntOp $R5 $R5 + 1
+        StrCpy $R4 $R4 "" $R5
+        Goto rpe_have_token
+      ${EndIf}
+      IntOp $R5 $R5 + 1
+      Goto rpe_find
+
+    rpe_have_token:
+      ${If} $R3 == ""
+        Goto rpe_loop
+      ${EndIf}
+      ; Strip a single trailing backslash for comparison
+      StrCpy $R8 $R3 "" -1
+      ${If} $R8 == "\"
+        StrCpy $R8 $R3 -1
+      ${Else}
+        StrCpy $R8 $R3
+      ${EndIf}
+      ; LogicLib '==' is case-insensitive — drops matching entry
+      ${If} $R8 == $R7
+        Goto rpe_loop
+      ${EndIf}
+      ${If} $R2 == ""
+        StrCpy $R2 $R3
+      ${Else}
+        StrCpy $R2 "$R2;$R3"
+      ${EndIf}
+      Goto rpe_loop
+
+  rpe_done:
+  Pop $R8
+  Pop $R7
+  Pop $R6
+  Pop $R5
+  Pop $R4
+  Pop $R3
+  Exch $R2
+  Exch
+  Pop $R1
+  Pop $R0
 FunctionEnd


### PR DESCRIPTION
Adds installers/windows/{console.nsi,build-installers.sh,README.md}, ported from the console repo's installer/macos branch (now superseded by this deployment-repo layout).

NSI installer ships two editions per build — UI (with system-tray) and headless — and provides optional Start Menu shortcuts, desktop shortcut, PATH entry, and run-at-startup. License page reads from ../../LICENSE since the .nsi now lives at installers/windows/console.nsi.

build-installers.sh follows the same dual-mode pattern as the macOS script: if BINARY_DIR contains prebuilt binaries, use them; otherwise build from the services/console submodule (CGO_ENABLED=1, -tags=tray for UI, -tags='tray noui' for headless).