### PR TITLE
ci(gh-actions): resolve zizmor findings

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -23,5 +23,7 @@ jobs:
 
       - name: 'Checkout Repository'
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0

--- a/.github/workflows/helm-lint.yml
+++ b/.github/workflows/helm-lint.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
       - name: Lint chart
         run: helm lint charts

--- a/.github/workflows/helm-tgz-asset.yml
+++ b/.github/workflows/helm-tgz-asset.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.ref }}
+          persist-credentials: false
 
       - name: Print github workspace
         run: echo $GITHUB_WORKSPACE && pwd && echo ${{ github.workspace }}

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
         with:
           configFile: ./.github/commitlint.config.cjs

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+---
+# Zizmor configuration. See https://docs.zizmor.sh/configuration/
+rules:
+  # Daily updates with no cooldown are intentional here. A version compromised
+  # at publish time can reach CI before it is yanked, but the blast radius is
+  # small: Dependabot PRs do not receive repository secrets by default and run
+  # with a read-only GITHUB_TOKEN.
+  dependabot-cooldown:
+    ignore:
+      - dependabot.yml


### PR DESCRIPTION
- Set persist-credentials: false on actions/checkout in dependency-review, helm-lint, helm-tgz-asset and semantic workflows; none of these jobs push with the checkout token.
- Add .github/zizmor.yml ignoring dependabot-cooldown, since the daily no-cooldown update cadence is intentional.